### PR TITLE
Add support for different filetypes

### DIFF
--- a/lib/yuml.rb
+++ b/lib/yuml.rb
@@ -54,9 +54,14 @@ module YUML
   end
 
   def fetch_uml(file)
-    uri = URI("https://yuml.me/diagram/class/#{yuml}.pdf")
+    uri = URI("https://yuml.me/diagram/class/#{yuml}#{extname(file)}")
     response = Net::HTTP.get_response(uri)
     File.write(file, response.body)
+  end
+
+  def extname(filename)
+    return '.pdf' unless %w(.pdf .png .jpg .jpeg).include?(File.extname(filename))
+    File.extname(filename).sub('.jpg', '.jpeg')
   end
 
   def encodings

--- a/spec/yuml_spec.rb
+++ b/spec/yuml_spec.rb
@@ -70,6 +70,14 @@ describe YUML do
       expect(File.exist?(@options[:file])).to be true
       expect(File.read(@options[:file])).to eq 'abc'
     end
+
+    it 'should add a valid filetype if an invalid on is specified' do
+      stub = stub_request(:any, %r{https://yuml.me/.*.pdf}).to_return(body: 'abc', status: 200)
+      YUML.generate(file: 'invalid.jjj') do |uml|
+        uml.class { name 'Document' }
+      end
+      expect(stub).to have_been_requested
+    end
   end
 
   describe '#attach_note' do


### PR DESCRIPTION
fixes #2 

This lets you name your file with `.png`, `.jpg`, `.jpeg`, or `.pdf`. It will default to `.pdf` if the extension type isn't correct or is missing.

```ruby
YUML.generate(file: 'tmp/my-diagram.png', &block)
```