### PR TITLE
Alias for cardinality to improve readability

### DIFF
--- a/lib/yuml/class.rb
+++ b/lib/yuml/class.rb
@@ -33,7 +33,8 @@ module YUML
       @methods << normalize(args)
     end
 
-    def has_a(dest, type: :aggregation, cardinality: nil)
+    def has_a(dest, type: :aggregation, cardinality: nil, association_name: cardinality)
+      cardinality ||= association_name
       type = :aggregation unless %i(composition aggregation).include?(type)
       relationship = YUML::Relationship.send(type, cardinality)
       @relationships << "[#{name}]#{relationship}[#{dest.name}]"
@@ -45,7 +46,8 @@ module YUML
       @relationships << "[#{dest.name}]#{relationship}[#{name}]"
     end
 
-    def associated_with(dest, type: :directed_assoication, cardinality: nil)
+    def associated_with(dest, type: :directed_assoication, cardinality: nil, association_name: cardinality)
+      cardinality ||= association_name
       type = :directed_assoication unless %i(
         association directed_assoication two_way_association dependency
       ).include?(type)

--- a/spec/yuml_class_spec.rb
+++ b/spec/yuml_class_spec.rb
@@ -95,6 +95,11 @@ describe YUML::Class do
       expect(@doc.relationships).to eq '[Document]+-*>[Picture]'
     end
 
+    it 'aliases cardinality to association_name' do
+      @doc.has_a(@pic, association_name: 'profilePhoto')
+      expect(@doc.relationships).to eq '[Document]+-profilePhoto>[Picture]'
+    end
+
     it 'should handle composition and cardinality' do
       @doc.has_a(@pic, type: :composition, cardinality: [0, '*'])
       expect(@doc.relationships).to eq '[Document]++0-*>[Picture]'
@@ -125,6 +130,11 @@ describe YUML::Class do
     it 'should handle an association with cardinality' do
       @doc.associated_with(@pic, cardinality: %w(uses used))
       expect(@doc.relationships).to eq '[Document]uses-used>[Picture]'
+    end
+
+    it 'aliases cardinality to association_name' do
+      @doc.has_a(@pic, association_name: 'profilePhoto')
+      expect(@doc.relationships).to eq '[Document]+-profilePhoto>[Picture]'
     end
 
     it 'should handle a bi directional associations with cardinality' do


### PR DESCRIPTION
fixes #3 

@mspork pointed out in #3 that the ability to name relationships (e.g. `[Customer]-primary[Contact]`, `[Customer]-secondary[Contact]`, etc) was missing.

In fact you could accomplish this by using the `cardinality` key when declaring an association. To fix this misconception I've aliased `association_name` to `cardinality`.

The following two lines now give identical behaviour, but the second is more readable and implicates the intent more clearly.

```ruby
customer.associated_with(contact, cardinality: 'profilePhoto')
customer.associated_with(contact, association_name: 'profilePhoto')
```